### PR TITLE
chore: add an entrypoint to run the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	./mvnw test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ cd testcontainers-cloud-java-example
 
 ## Run the test suite
 
-`./mvnw test`
+```shell
+make test
+```
+
+The `Make` command will run the test suite using `./mvnw test`
+
 
 ## Confirm your environment is configured correctly
 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,13 @@ For details on how to bootstrap Testcontainers in an actual project, please refe
 
 ## Clone the repository and run the first Testcontainers test suite
 
-```
+```shell
 git clone https://github.com/AtomicJar/testcontainers-cloud-java-example
 cd testcontainers-cloud-java-example
-```
-
-## Run the test suite
-
-```shell
 make test
 ```
 
-The `Make` command will run the test suite using `./mvnw test`
+The `Make` command will run the test suite using `./mvnw test`.
 
 
 ## Confirm your environment is configured correctly


### PR DESCRIPTION
## What does this PR do?
It adds an entrypoint using Make to run the tests with just a single command

## Why is it important?
It will implement the contract of all cloud examples to run tests with the very same command
 

