### PR TITLE
Waiting for DB listening port

### DIFF
--- a/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
+++ b/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.Transferable;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +23,8 @@ public class TestcontainersCloudFirstTest {
     @Test
     public void createPostgreSQLContainer() throws SQLException {
         try (PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:14-alpine")
-                .withCopyToContainer(Transferable.of(initsql), "/docker-entrypoint-initdb.d/init.sql")) {
+                .withCopyToContainer(Transferable.of(initsql), "/docker-entrypoint-initdb.d/init.sql")
+                .waitingFor(Wait.defaultWaitStrategy())) {
             postgreSQLContainer.start();
 			Connection connection = DriverManager.getConnection(postgreSQLContainer.getJdbcUrl(), postgreSQLContainer.getUsername(), postgreSQLContainer.getPassword());
 			PreparedStatement preparedStatement = connection.prepareStatement("SELECT COUNT(*) FROM guides");


### PR DESCRIPTION
Postgres was not available for test until wait added.
For new Testcontainers users it might be scary that example doesn't work out of the box.