### PR TITLE
Check for a label alongside of the server version

### DIFF
--- a/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
+++ b/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
@@ -1,12 +1,5 @@
 package cloud.testcontainers.example;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Arrays;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Info;
 import org.junit.jupiter.api.Test;
@@ -14,24 +7,41 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.shaded.com.google.common.collect.Streams;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(TccTestWatcher.class)
 public class TestcontainersCloudFirstTest {
 
+    public static final String DOCKER_CLOUD_VERSION_LABEL = "com.docker.cloud.version";
+
+    public static final String TESTCONTAINERS_DESKTOP_APP_NAME = "Testcontainers Desktop";
+
+    public static final String TESTCONTAINERS_CLOUD_VERSION_NAME = "testcontainerscloud";
+
     @Test
     public void createPostgreSQLContainer() throws SQLException {
         try (PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:14-alpine")
                 .withCopyToContainer(Transferable.of(initsql), "/docker-entrypoint-initdb.d/init.sql")) {
             postgreSQLContainer.start();
-			Connection connection = DriverManager.getConnection(postgreSQLContainer.getJdbcUrl(), postgreSQLContainer.getUsername(), postgreSQLContainer.getPassword());
-			PreparedStatement preparedStatement = connection.prepareStatement("SELECT COUNT(*) FROM guides");
-			preparedStatement.execute();
-			ResultSet resultSet = preparedStatement.getResultSet();
-			resultSet.next();
-			assertThat(resultSet.getInt(1)).isEqualTo(6);
-		}
+            Connection connection = DriverManager.getConnection(postgreSQLContainer.getJdbcUrl(), postgreSQLContainer.getUsername(), postgreSQLContainer.getPassword());
+            PreparedStatement preparedStatement = connection.prepareStatement("SELECT COUNT(*) FROM guides");
+            preparedStatement.execute();
+            ResultSet resultSet = preparedStatement.getResultSet();
+            resultSet.next();
+            assertThat(resultSet.getInt(1)).isEqualTo(6);
+        }
     }
 
     @Test
@@ -42,23 +52,28 @@ public class TestcontainersCloudFirstTest {
         String serverVersion = dockerInfo.getServerVersion();
         String[] labels = dockerInfo.getLabels();
 
-        boolean isCloudServer = labels != null && Arrays.asList(labels).contains("docker/cloud");
+        List<String> info = Streams.concat(
+                Stream.of(String.format("server.version=%s", serverVersion)),
+                Arrays.stream(labels == null ? new String[]{} : labels)
+        ).collect(Collectors.toList());
 
-        if (!isCloudServer) {
-            assertThat(serverVersion)
+        assertThat(info)
                 .as("Docker Client is configured via the Testcontainers desktop app")
-                .satisfiesAnyOf(
-                        dockerString -> assertThat(dockerString).contains("Testcontainers Desktop"),
-                        dockerString -> assertThat(dockerString).contains("testcontainerscloud")
-                );
-        }
+                .anySatisfy(it -> assertThat(it).containsAnyOf(
+                        TESTCONTAINERS_DESKTOP_APP_NAME,
+                        TESTCONTAINERS_CLOUD_VERSION_NAME,
+                        DOCKER_CLOUD_VERSION_LABEL
+                ));
 
+        logRuntimeDetails(serverVersion != null ? serverVersion : "", dockerInfo);
+    }
 
+    private static void logRuntimeDetails(String serverVersion, Info dockerInfo) {
         String runtimeName = "Testcontainers Cloud";
-        if (!serverVersion.contains("testcontainerscloud")) {
+        if (!serverVersion.contains(TESTCONTAINERS_CLOUD_VERSION_NAME)) {
             runtimeName = dockerInfo.getOperatingSystem();
         }
-        if (serverVersion.contains("Testcontainers Desktop")) {
+        if (serverVersion.contains(TESTCONTAINERS_DESKTOP_APP_NAME)) {
             runtimeName += " via Testcontainers Desktop app";
         }
         System.out.println(PrettyStrings.getLogo(runtimeName));
@@ -66,19 +81,19 @@ public class TestcontainersCloudFirstTest {
 
     private static final String initsql =
             "create table guides\n" +
-                "(\n" +
-                "    id         bigserial     not null,\n" +
-                "    title      varchar(1023)  not null,\n" +
-                "    url        varchar(1023) not null,\n" +
-                "    primary key (id)\n" +
-            ");\n" +
-            "\n" +
-            "insert into guides(title, url)\n" +
-            "values ('Getting started with Testcontainers', 'https://testcontainers.com/getting-started/'),\n" +
-            "       ('Getting started with Testcontainers for Java', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-java/'),\n" +
-            "       ('Getting started with Testcontainers for .NET', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-dotnet/'),\n" +
-            "       ('Getting started with Testcontainers for Node.js', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-nodejs/'),\n" +
-            "       ('Getting started with Testcontainers for Go', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-go/'),\n" +
-            "       ('Testcontainers container lifecycle management using JUnit 5', 'https://testcontainers.com/guides/testcontainers-container-lifecycle/')\n" +
-            ";";
+                    "(\n" +
+                    "    id         bigserial     not null,\n" +
+                    "    title      varchar(1023)  not null,\n" +
+                    "    url        varchar(1023) not null,\n" +
+                    "    primary key (id)\n" +
+                    ");\n" +
+                    "\n" +
+                    "insert into guides(title, url)\n" +
+                    "values ('Getting started with Testcontainers', 'https://testcontainers.com/getting-started/'),\n" +
+                    "       ('Getting started with Testcontainers for Java', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-java/'),\n" +
+                    "       ('Getting started with Testcontainers for .NET', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-dotnet/'),\n" +
+                    "       ('Getting started with Testcontainers for Node.js', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-nodejs/'),\n" +
+                    "       ('Getting started with Testcontainers for Go', 'https://testcontainers.com/guides/getting-started-with-testcontainers-for-go/'),\n" +
+                    "       ('Testcontainers container lifecycle management using JUnit 5', 'https://testcontainers.com/guides/testcontainers-container-lifecycle/')\n" +
+                    ";";
 }

--- a/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
+++ b/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
@@ -70,7 +70,12 @@ public class TestcontainersCloudFirstTest {
 
     private static void logRuntimeDetails(String serverVersion, Info dockerInfo) {
         String runtimeName = "Testcontainers Cloud";
-        if (!serverVersion.contains(TESTCONTAINERS_CLOUD_VERSION_NAME)) {
+        boolean hasCloudLabel = Stream.of(
+                dockerInfo.getLabels() != null
+                ? dockerInfo.getLabels()
+                : new String[]{}
+        ).anyMatch(label -> label.contains(DOCKER_CLOUD_VERSION_LABEL));
+        if (!serverVersion.contains(TESTCONTAINERS_CLOUD_VERSION_NAME) && !hasCloudLabel) {
             runtimeName = dockerInfo.getOperatingSystem();
         }
         if (serverVersion.contains(TESTCONTAINERS_DESKTOP_APP_NAME)) {

--- a/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
+++ b/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
@@ -5,6 +5,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Info;
@@ -39,12 +40,19 @@ public class TestcontainersCloudFirstTest {
         Info dockerInfo = client.infoCmd().exec();
 
         String serverVersion = dockerInfo.getServerVersion();
-        assertThat(serverVersion)
+        String[] labels = dockerInfo.getLabels();
+
+        boolean isCloudServer = labels != null && Arrays.asList(labels).contains("docker/cloud");
+
+        if (!isCloudServer) {
+            assertThat(serverVersion)
                 .as("Docker Client is configured via the Testcontainers desktop app")
                 .satisfiesAnyOf(
                         dockerString -> assertThat(dockerString).contains("Testcontainers Desktop"),
                         dockerString -> assertThat(dockerString).contains("testcontainerscloud")
-                        );
+                );
+        }
+
 
         String runtimeName = "Testcontainers Cloud";
         if (!serverVersion.contains("testcontainerscloud")) {

--- a/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
+++ b/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(TccTestWatcher.class)
 public class TestcontainersCloudFirstTest {
 
-    public static final String DOCKER_CLOUD_VERSION_LABEL = "com.docker.cloud.version";
+    public static final String DOCKER_CLOUD_VERSION_LABEL = "cloud.docker.run.version";
 
     public static final String TESTCONTAINERS_DESKTOP_APP_NAME = "Testcontainers Desktop";
 

--- a/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
+++ b/src/test/java/cloud/testcontainers/example/TestcontainersCloudFirstTest.java
@@ -74,7 +74,7 @@ public class TestcontainersCloudFirstTest {
             runtimeName = dockerInfo.getOperatingSystem();
         }
         if (serverVersion.contains(TESTCONTAINERS_DESKTOP_APP_NAME)) {
-            runtimeName += " via Testcontainers Desktop app";
+            runtimeName += " via Testcontainers Desktop";
         }
         System.out.println(PrettyStrings.getLogo(runtimeName));
     }


### PR DESCRIPTION
A proposal for how to tackle the server version transition via the Java example.

This would need to be repeated for:
* [testcontainers-cloud-go-example](https://github.com/AtomicJar/testcontainers-cloud-go-example)
* [testcontainers-cloud-nodejs-example](https://github.com/AtomicJar/testcontainers-cloud-nodejs-example)
* [testcontainers-cloud-dotnet-example](https://github.com/AtomicJar/testcontainers-cloud-dotnet-example)
* [testcontainers-cloud-rs-example](https://github.com/AtomicJar/testcontainers-cloud-rs-example)